### PR TITLE
FIX: add a null check to avoid NPE

### DIFF
--- a/src/main/java/us/msu/cse/repair/core/parser/ingredient/IngredientUtil.java
+++ b/src/main/java/us/msu/cse/repair/core/parser/ingredient/IngredientUtil.java
@@ -514,7 +514,7 @@ public class IngredientUtil {
 						return false;
 				} else {
 					ITypeBinding tb = rs.getExpression().resolveTypeBinding();
-					if (!tb.isAssignmentCompatible(methodReturnTypeBinding))
+					if (tb != null && !tb.isAssignmentCompatible(methodReturnTypeBinding))
 						return false;
 				}
 			} else {


### PR DESCRIPTION
Hi Yuan,
    This line may raise NPE in some projects beyond Defects4J v1.0, so the patch adds a null check.